### PR TITLE
Use the version of Node declared in the `package.json` file (from the `devfile/devfile-web` repo)

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Red Hat, Inc.
+# Copyright Red Hat
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: 'package.json'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
 
       - name: Setup Pages


### PR DESCRIPTION
In https://github.com/devfile/devfile-web/pull/97, we updated the Node.js version to the latest LTS (18).

But we forgot to update the version used in this repo, causing the `Deploy Landing Page to Pages` Workflow to fail since https://github.com/devfile/devfile-web/pull/97 has been merged in. See https://github.com/devfile-resources/devfile-resources.github.io/actions/runs/6282501181/job/17062003689

To make sure we keep this repo in sync with Node version changes done in `devfile/devfile-web`, this PR now relies on the Node version declared in `devfile/devfile-web`, which is checked out into the workspace of the job run.

This way, we have a single source of truth for our version of Node.

Ref https://github.com/devfile/api/issues/1117