### PR TITLE
Update actions and enable build job under PRs

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -122,7 +122,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name != 'pull_request'
+    if: ${{ github.event.action == 'devfile-web-deploy-landing-page' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
fixes https://github.com/devfile/api/issues/1744

## Update actions

-  `actions/checkout@v3` --> `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`
- `nrwl/nx-set-shas@v2` --> `nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3`
- `actions/setup-node@v3` --> `actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1`
- `actions/configure-pages@v2` --> `actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0`
- `actions/cache@v3` --> `actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3`
- `actions/upload-pages-artifact@v1` --> `actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1` (fixes https://github.com/devfile/api/issues/1744)
- `actions/deploy-pages@v1` --> `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5`

## Enable `build` under PRs

Enables the `build` job under PRs to verify most of the changes to the workflow are tested before merging into live CI to deploy landing page to devfile.io.