### PR TITLE
fix: change deprecated set-output to use GITHUB_OUTPUT env var

### DIFF
--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -62,14 +62,14 @@ jobs:
         id: detect-package-manager
         run: |
           if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "::set-output name=manager::yarn"
-            echo "::set-output name=command::install"
-            echo "::set-output name=runner::yarn"
+            echo "manager=yarn" >> "$GITHUB_OUTPUT"
+            echo "command=install" >> "$GITHUB_OUTPUT"
+            echo "runner=yarn" >> "$GITHUB_OUTPUT"
             exit 0
           elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "::set-output name=manager::npm"
-            echo "::set-output name=command::ci"
-            echo "::set-output name=runner::npx --no-install"
+            echo "manager=npm" >> "$GITHUB_OUTPUT"
+            echo "command=ci" >> "$GITHUB_OUTPUT"
+            echo "runner=npx --no-install" >> "$GITHUB_OUTPUT"
             exit 0
           else
             echo "Unable to determine packager manager"


### PR DESCRIPTION
## Description

Changes the deprecated `set-output` command to set the passed values to `GITHUB_OUTPUT` instead.

See devfile/api#1777.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to use current GitHub Actions syntax standards, replacing deprecated output syntax with the latest `$GITHUB_OUTPUT` method for improved compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->